### PR TITLE
Allowed more than one space as a delimiter

### DIFF
--- a/lib/myslog.rb
+++ b/lib/myslog.rb
@@ -64,7 +64,7 @@ class MySlog
       response[:date] = nil
     end
 
-    elems = record.split(" ")
+    elems = record.split(/( )+/)
     response[:user]          = elems[2].strip
     response[:host]          = elems[4].strip
     response[:host_ip]       = elems[5].strip[1...-1]


### PR DESCRIPTION
<p>fluent-plugin-mysqlslowqueryを使わせていただいております。</p>

<p>リモートからのクエリの場合、スロークエリログ中のユーザとホストの区切り文字として、以下のように複数のスペースが挿入される場合があります。(mysql-server-5.0.77-3.el5で確認)</p>

<pre># User@Host: user_r[user_r] @  [192.168.xxx.xxx]</pre>


<br>

<p>その場合、以下のようなログが出力され、該当のスロークエリログがパースされずに破棄されてしまいます。</p>

<pre>2012-08-15 16:28:55 +0900: ["# Query_time: 3  Lock_time: 0  Rows_sent: 1  Rows_examined: 0\n", "use information_schema; SELECT SLEEP(3);"] error="undefined method `strip' for nil:NilClass"</pre>


<br>

<p>複数スペースのセパレータに対応するようにmyslog.rbを修正いたしましたので、ご確認いただければ幸いです。
よろしくお願いいたします。</p>
