### PR TITLE
skip_name_resolvを設定している場合に対応

### DIFF
--- a/lib/myslog.rb
+++ b/lib/myslog.rb
@@ -66,8 +66,13 @@ class MySlog
 
     elems = record.split(" ")
     response[:user]          = elems[2].strip
-    response[:host]          = elems[4].strip
-    response[:host_ip]       = elems[5].strip[1...-1]
+    if elems[5] == nil
+      response[:host]        = nil
+      response[:host_ip]     = elems[4].strip[1...-1]
+    else
+      response[:host]        = elems[4].strip
+      response[:host_ip]     = elems[5].strip[1...-1]
+    end
 
     record = records.shift
     elems = record.split(" ")


### PR DESCRIPTION
fluent-plugin-mysqlslowqueryを使わせていただいておりますが、一定条件下でパースがエラーになりますのでプルリクさせていただきます。

<br>
mysqldの起動オプションで、skip-name-resolvを設定している場合、以下のようにスロークエリログにホスト名が出力されません。(代わりにスペースが出力される)

<pre># User@Host: user_r[user_r] @  [192.168.xxx.xxx]</pre>


<br>
その場合、以下のようなログが出力され、該当のスロークエリログがパースされずに破棄されてしまいます。

<pre>2012-08-15 16:28:55 +0900: ["# Query_time: 3  Lock_time: 0  Rows_sent: 1  Rows_examined: 0\n", "use information_schema; SELECT SLEEP(3);"] error="undefined method `strip' for nil:NilClass"</pre>


<br>
skip-name-resolvを設定している場合でもパースするように、myslog.rbを修正させていただきました。
ご確認いただければ幸いです。
よろしくお願いいたします。
