### PR TITLE
スペース2個によるパース漏れ対応

### DIFF
--- a/lib/myslog.rb
+++ b/lib/myslog.rb
@@ -66,7 +66,6 @@ class MySlog
         end
       elsif record.start_with? "#"
 
-        # split with two space
         elems = record[2..-1].strip().split " "
         if elems.size == 3 && elems[0] == "Time:"
           response[:date] = Time.parse(elems[1]+" "+elems[2])


### PR DESCRIPTION
私の手元のMySQLスロークエリログの形式(Amazon RDS(MySQL5.5.27)からダウンロードしたスロークエリログ)で、以下のような形式のログが出力されました。

```
# Time: 130312  8:06:00
# User@Host: zabbix[zabbix] @ localhost []
# Query_time: 1.128693  Lock_time: 0.000026 Rows_sent: 0  Rows_examined: 461012
SET timestamp=1363043192;
delete from sessions where lastaccess<1331507877;
```

このログにおいて、Lock_tmeとRows_sentの間がスペース1個になっていたためmyslogでのparseに失敗していました。
そこで、スペース2個を判断して区切るロジックから変更してみました。
少し強引なやり方かもしれませんが、マージしていただけると有難いです。
