### PR TITLE
The parse when binary is included in insert sentence

### DIFF
--- a/lib/myslog.rb
+++ b/lib/myslog.rb
@@ -19,7 +19,7 @@ class MySlog
       end
 
       sql = []
-      while line != nil && !line.start_with?("#")
+      while line != nil && !line.start_with?("# Time") && !line.start_with?("# User@Host") && !line.start_with?("# Query_time")
         sql << line.strip
         line = lines.shift
       end


### PR DESCRIPTION
バイナリを含むINSERT文がログにあった場合に正しくパースできていなかったので修正しました。
強引なやり方かもしれませんが、マージしていただけると有難いです。