### PR TITLE
Change parse logic to support new log format for MySQL5.7

### DIFF
--- a/lib/myslog.rb
+++ b/lib/myslog.rb
@@ -52,6 +52,8 @@ class MySlog
         elems = record[2..-1].strip().split " "
         if elems.size == 3 && elems[0] == "Time:"
           response[:date] = Time.parse(elems[1]+" "+elems[2])
+        elsif elems.size == 2 && elems[0] == "Time:"
+          response[:date] = Time.parse(elems[1][0..9]+" "+elems[1][11..18])
         else
           elems.each_with_index do |elem,i|
             if elem.include?(":") && !elems[i+1].include?(":")


### PR DESCRIPTION

I changed parse logic to support new log format for MySQL5.7.
I confirmed to be able to get log of previous version format and new format.